### PR TITLE
Fetch latest issue

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -38039,28 +38039,30 @@ function fetchProperties(options) {
         });
         core.debug(`Current project data: ${JSON.stringify(projectData, null, 2)}`);
         const gitHubRepo = getRepoFullNameFromPayload(payload);
-        const issue = yield octokit.request('GET /repos/{owner}/{repo}/issues/{issue_number}', {
+        const issueResp = yield octokit.request('GET /repos/{owner}/{repo}/issues/{issue_number}', {
             owner: getOwnerFromRepoFullName(gitHubRepo),
             repo: getRepoNameFromRepoFullName(gitHubRepo),
             issue_number: payload.issue.number,
         });
-        // print issue
-        console.log(issue);
+        if (issueResp.status !== 200) {
+            throw new Error(`Failed to fetch issue data: ${issueResp.status}`);
+        }
+        const issue = issueResp.data;
         const result = {
-            Name: properties_1.properties.title(payload.issue.title),
-            Status: properties_1.properties.getStatusSelectOption(payload.issue.state),
+            Name: properties_1.properties.title(issue.title),
+            Status: properties_1.properties.getStatusSelectOption(issue.state),
             Organization: properties_1.properties.text((_c = (_b = payload.organization) === null || _b === void 0 ? void 0 : _b.login) !== null && _c !== void 0 ? _c : ''),
             Repository: properties_1.properties.text(payload.repository.name),
-            Number: properties_1.properties.number(payload.issue.number),
-            Body: properties_1.properties.richText(parseBodyRichText(payload.issue.body)),
-            Assignees: properties_1.properties.multiSelect(payload.issue.assignees.map(assignee => assignee.login)),
-            Milestone: properties_1.properties.text((_e = (_d = payload.issue.milestone) === null || _d === void 0 ? void 0 : _d.title) !== null && _e !== void 0 ? _e : ''),
-            Labels: properties_1.properties.multiSelect((_g = (_f = payload.issue.labels) === null || _f === void 0 ? void 0 : _f.map(label => label.name)) !== null && _g !== void 0 ? _g : []),
-            Author: properties_1.properties.text(payload.issue.user.login),
-            Created: properties_1.properties.date(payload.issue.created_at),
-            Updated: properties_1.properties.date(payload.issue.updated_at),
-            ID: properties_1.properties.number(payload.issue.id),
-            Link: properties_1.properties.url(payload.issue.html_url),
+            Number: properties_1.properties.number(issue.number),
+            Body: properties_1.properties.richText(parseBodyRichText(issue.body)),
+            Assignees: properties_1.properties.multiSelect(issue.assignees.map(assignee => assignee.login)),
+            Milestone: properties_1.properties.text((_e = (_d = issue.milestone) === null || _d === void 0 ? void 0 : _d.title) !== null && _e !== void 0 ? _e : ''),
+            Labels: properties_1.properties.multiSelect((_g = (_f = issue.labels) === null || _f === void 0 ? void 0 : _f.map(label => label.name)) !== null && _g !== void 0 ? _g : []),
+            Author: properties_1.properties.text(issue.user.login),
+            Created: properties_1.properties.date(issue.created_at),
+            Updated: properties_1.properties.date(issue.updated_at),
+            ID: properties_1.properties.number(issue.id),
+            Link: properties_1.properties.url(issue.html_url),
             Project: properties_1.properties.text((projectData === null || projectData === void 0 ? void 0 : projectData.name) || ''),
             'Project Column': properties_1.properties.text((projectData === null || projectData === void 0 ? void 0 : projectData.columnName) || ''),
         };

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,6 +1,6 @@
 import {Client, LogLevel} from '@notionhq/client/build/src';
 import * as core from '@actions/core';
-import type {IssuesEvent} from '@octokit/webhooks-definitions/schema';
+import type {IssuesEvent, Issue} from '@octokit/webhooks-definitions/schema';
 import type {WebhookPayload} from '@actions/github/lib/interfaces';
 import {CustomValueMap, properties} from './properties';
 import {createIssueMapping, syncNotionDBWithGitHub} from './sync';
@@ -42,21 +42,23 @@ async function fetchProperties(options: PayloadParsingOptions): Promise<CustomVa
     throw new Error(`Failed to fetch issue data: ${issueResp.status}`);
   }
 
+  const issue = issueResp.data as Issue;
+
   const result: CustomValueMap = {
-    Name: properties.title(issueResp.data.title),
-    Status: properties.getStatusSelectOption(issueResp.data.state!),
+    Name: properties.title(issue.title),
+    Status: properties.getStatusSelectOption(issue.state!),
     Organization: properties.text(payload.organization?.login ?? ''),
     Repository: properties.text(payload.repository.name),
-    Number: properties.number(issueResp.data.number),
-    Body: properties.richText(parseBodyRichText(issueResp.data.body)),
-    Assignees: properties.multiSelect(issueResp.data.assignees.map(assignee => assignee.login)),
-    Milestone: properties.text(issueResp.data.milestone?.title ?? ''),
-    Labels: properties.multiSelect(issueResp.data.labels?.map(label => label.name) ?? []),
-    Author: properties.text(issueResp.data.user.login),
-    Created: properties.date(issueResp.data.created_at),
-    Updated: properties.date(issueResp.data.updated_at),
-    ID: properties.number(issueResp.data.id),
-    Link: properties.url(issueResp.data.html_url),
+    Number: properties.number(issue.number),
+    Body: properties.richText(parseBodyRichText(issue.body)),
+    Assignees: properties.multiSelect(issue.assignees.map(assignee => assignee.login)),
+    Milestone: properties.text(issue.milestone?.title ?? ''),
+    Labels: properties.multiSelect(issue.labels?.map(label => label.name) ?? []),
+    Author: properties.text(issue.user.login),
+    Created: properties.date(issue.created_at),
+    Updated: properties.date(issue.updated_at),
+    ID: properties.number(issue.id),
+    Link: properties.url(issue.html_url),
     Project: properties.text(projectData?.name || ''),
     'Project Column': properties.text(projectData?.columnName || ''),
   };


### PR DESCRIPTION
GitHub Actions could sometimes re-order the events e.g.
1. label add
2. assign
3. create

This could cause the notion github action to pick up state from an earlier event. This change would make sure the action always works with the latest state in GitHub.
Also, there shouldn't be a need to serialize actions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/notion-github-action/5)
<!-- Reviewable:end -->
